### PR TITLE
Fix: Get Cesium weather app working

### DIFF
--- a/open.html
+++ b/open.html
@@ -53,6 +53,5 @@
     <script src="https://unpkg.com/to-geojson" defer></script>
     <script src="https://unpkg.com/xlsx@0.17.0/dist/xlsx.full.min.js" defer></script>
     <script src="open/bundle.js"></script>
-    <script src="open.js" defer></script>
 </body>
 </html>

--- a/open.js
+++ b/open.js
@@ -76,11 +76,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
             console.log(aiResponse);
 
-            if (aiResponse.choices && aiResponse.choices.length > 0) {
-                const advice = aiResponse.choices[0].text.trim();
+            if (aiResponse.candidates && aiResponse.candidates.length > 0 &&
+                aiResponse.candidates[0].content && aiResponse.candidates[0].content.parts &&
+                aiResponse.candidates[0].content.parts.length > 0) {
+                const advice = aiResponse.candidates[0].content.parts[0].text.trim();
                 forecast.textContent = `AI Advice: ${advice}`;
             } else {
-                forecast.textContent = 'AI Advice: No advice available at the moment or The server is too busy at the moment';
+                console.error('Unexpected Gemini API response structure:', aiResponse);
+                forecast.textContent = 'AI Advice: Could not retrieve advice due to an unexpected response format.';
             }
 
             const speech = new SpeechSynthesisUtterance(forecast.textContent);

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "scripts": {
-    "build": "webpack --config webpack.config.js"
+    "build": "webpack --config webpack.config.js",
+    "start": "webpack serve --open open/open.html"
   },
   "devDependencies": {
     "dotenv": "^16.4.5",
     "webpack": "^5.93.0",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   },
   "dependencies": {
     "cesium": "^1.91.0",


### PR DESCRIPTION
This commit addresses the blank screen issue by focusing on the Cesium-based weather application in `open.html` and `open.js`.

Key changes include:
- Configured Webpack to use .env for API keys.
- Added webpack-dev-server and an `npm start` script.
- Cleaned up `open.html` by removing a redundant script tag.
- Corrected the Gemini API response parsing in `open.js`.
- The Three.js application in `index.html` and `main.js` remains as is, with known issues of missing assets and non-functional conceptual Firebase code.

The Cesium application should now load, display the globe, fetch weather data, and provide AI-generated advice, provided you have valid API keys in the .env file.